### PR TITLE
chore: configure python-semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Semantic Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    concurrency: release
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Python Semantic Release
+      uses: python-semantic-release/python-semantic-release@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        repository_username: __token__
+        repository_password: ${{ secrets.PYPI_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,3 +12,4 @@ To ensure effecient collaborative development, a variety of standards are utilis
 - [Semantic Versioning](https://semver.org) is used.
 - [Conventional Commits](https://www.conventionalcommits.org/) are utilised and validated using the [wagoid/commitlint-github-action](https://github.com/wagoid/commitlint-github-action) github action, which itself uses [commitlint](https://github.com/conventional-changelog/commitlint)
   - Conventional Commmits are also utilised for pull request titles and enforced using [amannn/action-semantic-pull-request](https://github.com/amannn/action-semantic-pull-request).
+- [Python Semantic Releases](https://github.com/python-semantic-release/python-semantic-release) is used to automate change log generation and releases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,4 +58,7 @@ exclude_lines = [
 
 [tool.semantic_release]
 version_variable = "conversations/__about__.py:__version__"
-version_source = "commit"
+version_source = "tag"
+tag_commit = true
+branch = "main"
+commit_parser = "semantic_release.history.angular_parser"


### PR DESCRIPTION
Use tags to track versions rather than commits.