### PR TITLE
fix: set default number of speakers to 0

### DIFF
--- a/conversations/_conversations.py
+++ b/conversations/_conversations.py
@@ -22,7 +22,7 @@ class Conversation:
     def __init__(
         self,
         recording: Path,
-        num_speakers: int = 2,
+        num_speakers: int = 0,
         reload: bool = True,
         speaker_mapping: Optional[Dict[str, str]] = None,
         meeting_datetime: Optional[datetime] = None,
@@ -39,7 +39,7 @@ class Conversation:
         recording : pathlib.Path
             Path to the conversation recording.
         num_speakers : int
-            The number of speakers in the conversation.
+            The number of speakers in the conversation, defaulting to 0 if unknown.
         reload : bool
             If True, try to load an existing saved conversation with the default filename.
             If False, create a new Conversation instance.
@@ -90,13 +90,13 @@ class Conversation:
                 print(f"- {attendee}")
 
         # Set num_speakers based on attendees if not provided
-        if num_speakers is None and attendees is not None:
+        if num_speakers == 0 and attendees is not None:
             self._num_speakers = len(attendees)
         else:
             self._num_speakers = num_speakers
 
         # Verify that num_speakers is equal to the number of attendees
-        if num_speakers is not None and attendees is not None:
+        if num_speakers > 0 and attendees is not None:
             if num_speakers != len(attendees):
                 raise ValueError(
                     "The number of speakers must match the number of attendees."

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -145,7 +145,7 @@ def test_meeting_datetime():
 def test_attendees():
     attendees = ["Alice", "Bob", "Charlie"]
     conv_with_attendees = Conversation(
-        recording=audio_file, attendees=attendees, reload=False, num_speakers=None
+        recording=audio_file, attendees=attendees, reload=False
     )
     assert conv_with_attendees._attendees == attendees
     assert conv_with_attendees._num_speakers == len(attendees)


### PR DESCRIPTION
This enables assembly diarisation to set the number of speakers if not set

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rob-luke/conversations?shareId=c762efb5-7fe5-48d6-b8cd-deb15dbc9d62).