### PR TITLE
feat: Add openai_speech_model setting

### DIFF
--- a/conversations/config.py
+++ b/conversations/config.py
@@ -6,6 +6,7 @@ from pydantic_settings import BaseSettings
 class OpenAISettings(BaseSettings):
     """Settings for OpenAI API, primarily the text model."""
 
+    openai_speech_model: str = "whisper-1"
     openai_text_model: str = "gpt-4.1-mini"
     max_prompt_tokens: int = 900000
     """Max tokens for AI processing chunks and final transcript target."""

--- a/conversations/transcribe/whisper/_whisper.py
+++ b/conversations/transcribe/whisper/_whisper.py
@@ -64,7 +64,9 @@ def _cloud_whisper(
     """
     if prompt is None:
         result = client.audio.transcriptions.create(
-            file=audio_file, model=settings.openai_speech_model, response_format="verbose_json"
+            file=audio_file,
+            model=settings.openai_speech_model,
+            response_format="verbose_json",
         )
     else:
         result = client.audio.transcriptions.create(

--- a/conversations/transcribe/whisper/_whisper.py
+++ b/conversations/transcribe/whisper/_whisper.py
@@ -4,6 +4,8 @@ from typing import Dict
 from openai import OpenAI
 import whisper
 
+from conversations.config import settings
+
 client = OpenAI()
 
 
@@ -62,11 +64,11 @@ def _cloud_whisper(
     """
     if prompt is None:
         result = client.audio.transcriptions.create(
-            file=audio_file, model="whisper-1", response_format="verbose_json"
+            file=audio_file, model=settings.openai_speech_model, response_format="verbose_json"
         )
     else:
         result = client.audio.transcriptions.create(
-            model="whisper-1",
+            model=settings.openai_speech_model,
             file=audio_file,
             response_format="verbose_json",
             prompt=prompt,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,6 +5,10 @@ def test_load_settings():
     assert settings.openai_text_model == "gpt-4.1-mini"
 
 
+def test_openai_speech_model_default_value():
+    assert settings.openai_speech_model == "whisper-1"
+
+
 def test_openai_token_settings_default_values():
     """Test that the token settings have the correct default values."""
     assert settings.max_prompt_tokens == 900000


### PR DESCRIPTION
Introduces a new configuration setting `openai_speech_model` in `conversations/config.py` with a default value of "whisper-1". This allows you to customize the OpenAI speech model used for audio transcription via the cloud API.

The `_cloud_whisper` function in
`conversations/transcribe/whisper/_whisper.py` has been updated to use this new `settings.openai_speech_model`.

The existing `openai_text_model` setting (defaulting to "gpt-4.1-mini") remains unchanged.

I've updated the tests in `tests/test_config.py`:
- Ensured that `openai_text_model` is still tested for its default.
- Added a new test for `openai_speech_model` to verify its default value.