### PR TITLE
Add optional extras for local processing

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,12 @@ can be found [here](https://rob-luke.github.io/conversations/).
 pip install conversations
 ```
 
+Install the optional dependencies for local processing with:
+
+```console
+pip install conversations[local]
+```
+
 ## Usage
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,17 +23,21 @@ classifiers = [
 
 dependencies = [
   "dominate",
-  "toml",
-  "soundfile",
-  "simple-diarizer",
-  "speechbrain==0.5.13",
   "openai>=1.2.0",
   "pooch",
-  "openai-whisper",
+  "assemblyai",
   "pydantic>=2.0.0",
   "pydantic-settings>=2.0.0",
 ]
 dynamic = ["version"]
+
+[project.optional-dependencies]
+local = [
+  "openai-whisper",
+  "simple-diarizer",
+  "speechbrain==0.5.13",
+  "soundfile",
+]
 
 [project.urls]
 Documentation = "https://github.com/rob-luke/conversations#readme"


### PR DESCRIPTION
## Summary
- add an optional `local` extra with heavy dependencies
- keep standard install small
- document how to install the optional dependencies

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6842cfa602c8832abbabc4059f3c240d