### PR TITLE
feat: refine custom terms for assembly ai

### DIFF
--- a/conversations/_conversations.py
+++ b/conversations/_conversations.py
@@ -113,6 +113,7 @@ class Conversation:
         model: str = "nano",
         prompt: str | None = " - How are you? - I'm fine, thank you.",
         language: str = "en",
+        custom_terms: Optional[List[str]] = None,
     ):
         """
         Transcribe a conversation using the specified method and model.
@@ -130,6 +131,9 @@ class Conversation:
             An optional prompt to be used for transcription, defaults to None.
         language : str, optional
             The language of the conversation, defaults to "en".
+        custom_terms : list[str], optional
+            Custom terms passed to the transcription engine. Currently
+            only supported when using the AssemblyAI ``"slam-1"`` model.
 
         Returns
         -------
@@ -181,7 +185,10 @@ class Conversation:
             from .transcribe import assembly
 
             self._transcription = assembly.process(
-                audio_file=self._recording, model_name=model, language=language
+                audio_file=self._recording,
+                model_name=model,
+                language=language,
+                custom_terms=custom_terms,
             )
 
             # by default, we use assembly to diarise the conversation too

--- a/conversations/transcribe/assembly/_assembly.py
+++ b/conversations/transcribe/assembly/_assembly.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict
+from typing import Dict, List, Optional
 import os
 
 import assemblyai as aai  # type: ignore
@@ -12,18 +12,22 @@ def process(
     audio_file: Path,
     model_name: str = "nano",
     language: str = "en",
+    custom_terms: Optional[List[str]] = None,
 ) -> Dict[str, str]:
-    """Transcribe audio using Whisper.
+    """Transcribe audio using AssemblyAI.
 
     Parameters
     ----------
     audio_file : Path
         Path to the audio file.
-    model_name : str, optionalππ
+    model_name : str, optional
         Name of the assembly model to use. To use the cloud service
         provided by Assembly, use "nano", "slam-1", "universal", or "best".
     language : str, optional
         Language to use for the transcription, by default "en".
+    custom_terms : list[str], optional
+        Custom terms to help the speech model with specific vocabulary.
+        Only used when ``model_name`` is ``"slam-1"``.
 
     Returns
     -------
@@ -49,7 +53,7 @@ def process(
         config = aai.TranscriptionConfig(
             speech_model=speech_model,
             language_code=language,
-            keyterms_prompt=["robert", "venture"],
+            keyterms_prompt=custom_terms,
             filter_profanity=False,
             speaker_labels=True,
         )

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ speaker_mapping={"0": "Alice", "1": "Bob", "2": "Sam"}
 conversation = Conversation(recording=audio_file, speaker_mapping=speaker_mapping)
 
 # Process the conversation
-conversation.transcribe()
+conversation.transcribe(custom_terms=["Alice", "Bob"])
 conversation.diarise()
 conversation.save()
 


### PR DESCRIPTION
## Summary
- align type hints for `custom_terms` in AssemblyAI transcription
- remove placeholder defaults for assembly key term prompts

## Testing
- `hatch run cov` *(fails: OpenAIError and TranscriptError)*
- `hatch -v run lint`


------
https://chatgpt.com/codex/tasks/task_e_685d063e2128832ab338f8180db8db87